### PR TITLE
Add support for setting SNTP servers via DHCPv6

### DIFF
--- a/glue-lwip/arduino/lwipopts.h
+++ b/glue-lwip/arduino/lwipopts.h
@@ -2700,7 +2700,7 @@
  * void dhcp6_set_ntp_servers(u8_t num_ntp_servers, ip_addr_t* ntp_server_addrs);
 */
 #if !defined LWIP_DHCP6_GET_NTP_SRV || defined __DOXYGEN__
-#define LWIP_DHCP6_GET_NTP_SRV          0 // with 1: dhcp6_set_ntp_servers() must be implemented
+#define LWIP_DHCP6_GET_NTP_SRV          1 // with 1: dhcp6_set_ntp_servers() must be implemented
 #endif
 
 /**

--- a/glue-lwip/lwip-git.c
+++ b/glue-lwip/lwip-git.c
@@ -286,7 +286,8 @@ static void netif_sta_status_callback (struct netif* netif)
 		// this is our default route
 		netif_set_default(netif);
 			
-		if (ip_2_ip4(&netif->ip_addr)->addr)
+		// If we have a valid address of any type restart SNTP
+		if (ip_addr_isany(&netif->ip_addr))
 		{
 			// restart sntp
 			sntp_stop();

--- a/patches/0001-Implement-RFC4075-Receive-SNTP-servers-via-DHCPv6.patch
+++ b/patches/0001-Implement-RFC4075-Receive-SNTP-servers-via-DHCPv6.patch
@@ -1,0 +1,168 @@
+From 029452a17e002849d94ce6d5f2e9d7e059384c3e Mon Sep 17 00:00:00 2001
+From: "David J. Fiddes" <D.J@fiddes.net>
+Date: Sat, 19 Jan 2019 12:21:56 +0000
+Subject: [PATCH] Implement RFC4075 Receive SNTP servers via DHCPv6
+
+This adds support for RFC4075 SNTP server configuration via DHCPv6.
+The DHCPv6 options transmitted are now conditional on how LwIP is
+configured.
+
+A new SNTP application option SNTP_GET_SERVERS_FROM_DHCPV6 is used
+to enable. For simplicity this is configured to use the global
+LWIP_DHCP6_GET_NTP_SRV configuration setting.
+
+Tests:
+ - Check the global options now control the DHCPv6 request sent
+   in Wireshark
+ - Check against 0, 1 and 3 SNTP servers configured on an odhcpd
+   server configured to support RFC 4075 SNTP server lists.
+   Verify that the SNTP server list is updated on connection
+   establishment on an ESP8266 WeMOS D1.
+ - Verify that SNTP packets are sent and recieved from a
+   configured server and that system time is updated.
+
+Signed-off-by: David J. Fiddes <D.J@fiddes.net>
+---
+ src/apps/sntp/sntp.c              | 36 +++++++++++++++++++++++++++----
+ src/core/ipv6/dhcp6.c             | 11 +++++++++-
+ src/include/lwip/apps/sntp.h      |  6 +++---
+ src/include/lwip/apps/sntp_opts.h |  6 ++++++
+ 4 files changed, 51 insertions(+), 8 deletions(-)
+
+diff --git a/src/apps/sntp/sntp.c b/src/apps/sntp/sntp.c
+index b7ff56ad..3cccaf52 100644
+--- a/src/apps/sntp/sntp.c
++++ b/src/apps/sntp/sntp.c
+@@ -238,9 +238,9 @@ struct sntp_server {
+ };
+ static struct sntp_server sntp_servers[SNTP_MAX_SERVERS];
+ 
+-#if SNTP_GET_SERVERS_FROM_DHCP
++#if SNTP_GET_SERVERS_FROM_DHCP || SNTP_GET_SERVERS_FROM_DHCPV6
+ static u8_t sntp_set_servers_from_dhcp;
+-#endif /* SNTP_GET_SERVERS_FROM_DHCP */
++#endif /* SNTP_GET_SERVERS_FROM_DHCP || SNTP_GET_SERVERS_FROM_DHCPV6 */
+ #if SNTP_SUPPORT_MULTIPLE_SERVERS
+ /** The currently used server (initialized to 0) */
+ static u8_t sntp_current_server;
+@@ -648,6 +648,7 @@ void
+ sntp_init(void)
+ {
+   /* LWIP_ASSERT_CORE_LOCKED(); is checked by udp_new() */
++  LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp_init: SNTP initialised\n"));
+ 
+ #ifdef SNTP_SERVER_ADDRESS
+ #if SNTP_SERVER_DNS
+@@ -750,7 +751,7 @@ sntp_getreachability(u8_t idx)
+ }
+ #endif /* SNTP_MONITOR_SERVER_REACHABILITY */
+ 
+-#if SNTP_GET_SERVERS_FROM_DHCP
++#if SNTP_GET_SERVERS_FROM_DHCP || SNTP_GET_SERVERS_FROM_DHCPV6
+ /**
+  * Config SNTP server handling by IP address, name, or DHCP; clear table
+  * @param set_servers_from_dhcp enable or disable getting server addresses from dhcp
+@@ -764,7 +765,7 @@ sntp_servermode_dhcp(int set_servers_from_dhcp)
+     sntp_set_servers_from_dhcp = new_mode;
+   }
+ }
+-#endif /* SNTP_GET_SERVERS_FROM_DHCP */
++#endif /* SNTP_GET_SERVERS_FROM_DHCP || SNTP_GET_SERVERS_FROM_DHCPV6 */
+ 
+ /**
+  * @ingroup sntp
+@@ -816,6 +817,33 @@ dhcp_set_ntp_servers(u8_t num, const ip4_addr_t *server)
+ }
+ #endif /* LWIP_DHCP && SNTP_GET_SERVERS_FROM_DHCP */
+ 
++#if LWIP_IPV6_DHCP6 && SNTP_GET_SERVERS_FROM_DHCPV6
++/**
++ * Initialize one of the NTP servers by IP address, required by DHCPV6
++ *
++ * @param num the number of NTP server addresses to set must be < SNTP_MAX_SERVERS
++ * @param server array of IP address of the NTP servers to set
++ */
++void
++dhcp6_set_ntp_servers(u8_t num_ntp_servers, ip_addr_t* ntp_server_addrs)
++{
++  LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp: %s %u NTP server(s) via DHCPv6\n",
++                                 (sntp_set_servers_from_dhcp ? "Got" : "Rejected"),
++                                 num_ntp_servers));
++  if (sntp_set_servers_from_dhcp && num_ntp_servers) {
++    u8_t i;
++    for (i = 0; (i < num_ntp_servers) && (i < SNTP_MAX_SERVERS); i++) {
++      LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp: NTP server %u: %s\n",
++                                     i, ipaddr_ntoa(&ntp_server_addrs[i])));
++      sntp_setserver(i, &ntp_server_addrs[i]);
++    }
++    for (i = num_ntp_servers; i < SNTP_MAX_SERVERS; i++) {
++      sntp_setserver(i, NULL);
++    }
++  }
++}
++#endif /* LWIP_DHCPv6 && SNTP_GET_SERVERS_FROM_DHCPV6 */
++
+ /**
+  * @ingroup sntp
+  * Obtain one of the currently configured by IP address (or DHCP) NTP servers
+diff --git a/src/core/ipv6/dhcp6.c b/src/core/ipv6/dhcp6.c
+index 7cf98a52..dbc02bed 100644
+--- a/src/core/ipv6/dhcp6.c
++++ b/src/core/ipv6/dhcp6.c
+@@ -451,7 +451,16 @@ dhcp6_msg_finalize(u16_t options_out_len, struct pbuf *p_out)
+ static void
+ dhcp6_information_request(struct netif *netif, struct dhcp6 *dhcp6)
+ {
+-  const u16_t requested_options[] = {DHCP6_OPTION_DNS_SERVERS, DHCP6_OPTION_DOMAIN_LIST, DHCP6_OPTION_SNTP_SERVERS};
++  const u16_t requested_options[] = {
++#if LWIP_DHCP6_PROVIDE_DNS_SERVERS
++    DHCP6_OPTION_DNS_SERVERS, 
++    DHCP6_OPTION_DOMAIN_LIST
++#endif
++#if LWIP_DHCP6_GET_NTP_SRV
++    , DHCP6_OPTION_SNTP_SERVERS
++#endif
++  };
++  
+   u16_t msecs;
+   struct pbuf *p_out;
+   u16_t options_out_len;
+diff --git a/src/include/lwip/apps/sntp.h b/src/include/lwip/apps/sntp.h
+index 3c0f95f7..c4152534 100644
+--- a/src/include/lwip/apps/sntp.h
++++ b/src/include/lwip/apps/sntp.h
+@@ -67,11 +67,11 @@ void sntp_setservername(u8_t idx, const char *server);
+ const char *sntp_getservername(u8_t idx);
+ #endif /* SNTP_SERVER_DNS */
+ 
+-#if SNTP_GET_SERVERS_FROM_DHCP
++#if SNTP_GET_SERVERS_FROM_DHCP || SNTP_GET_SERVERS_FROM_DHCPV6
+ void sntp_servermode_dhcp(int set_servers_from_dhcp);
+-#else /* SNTP_GET_SERVERS_FROM_DHCP */
++#else /* SNTP_GET_SERVERS_FROM_DHCP || SNTP_GET_SERVERS_FROM_DHCPV6 */
+ #define sntp_servermode_dhcp(x)
+-#endif /* SNTP_GET_SERVERS_FROM_DHCP */
++#endif /* SNTP_GET_SERVERS_FROM_DHCP || SNTP_GET_SERVERS_FROM_DHCPV6 */
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/src/include/lwip/apps/sntp_opts.h b/src/include/lwip/apps/sntp_opts.h
+index ed98040f..cb627716 100644
+--- a/src/include/lwip/apps/sntp_opts.h
++++ b/src/include/lwip/apps/sntp_opts.h
+@@ -67,6 +67,12 @@
+ #define SNTP_GET_SERVERS_FROM_DHCP LWIP_DHCP_GET_NTP_SRV
+ #endif
+ 
++/** Set this to 1 to implement the callback function called by dhcpv6 when
++ * NTP servers are received. */
++#if !defined SNTP_GET_SERVERS_FROM_DHCPV6 || defined __DOXYGEN__
++#define SNTP_GET_SERVERS_FROM_DHCPV6 LWIP_DHCP6_GET_NTP_SRV
++#endif
++
+ /** Set this to 1 to support DNS names (or IP address strings) to set sntp servers
+  * One server address/name can be defined as default if SNTP_SERVER_DNS == 1:
+  * \#define SNTP_SERVER_ADDRESS "pool.ntp.org"
+-- 
+2.20.1
+


### PR DESCRIPTION
This bring parity between DHCPv4 and DHCPv6 allowing DHCPv6
servers to specify an SNTP server to use. Only a single SNTP
server slot is allocated to DHCPv6 (the same as v4).

Tests:
 - Start a WeMos D1 on a network which only provides IPv6
   addresses via DHCPv6 with 0, 1 or 3 SNTP servers
   configured
 - Verify that the SNTP is configured and that time is
   correct with an updated IPv6.ino sketch that reports
   SNTP servers and the current time

Signed-off-by: David J. Fiddes <D.J@fiddes.net>