### PR TITLE
Restart SNTP client when we have an IPv4 or IPv6 address

### DIFF
--- a/glue-lwip/lwip-git.c
+++ b/glue-lwip/lwip-git.c
@@ -287,8 +287,15 @@ static void netif_sta_status_callback (struct netif* netif)
 		netif_set_default(netif);
 			
 		// If we have a valid address of any type restart SNTP
-		if (ip_addr_isany(&netif->ip_addr))
-		{
+		bool valid_address = ip_2_ip4(&netif->ip_addr)->addr;
+
+#if LWIP_IPV6
+		int addrindex;
+		for (addrindex = 0; addrindex < LWIP_IPV6_NUM_ADDRESSES; addrindex++) {
+			valid_address |= ip6_addr_isvalid(netif_ip6_addr_state(netif, addrindex));
+		}
+#endif
+		if (valid_address)		{
 			// restart sntp
 			sntp_stop();
 			sntp_init();


### PR DESCRIPTION
This fixes the restarting of the SNTP client when the network
interface has a valid IP address. This was broken in changeset
9246ef for IPv4.

Note that for IPv6 the SNTP server can take up to 15 seconds to
be used due to the async nature of stateless DHCPv6 and SLAAC.
For IPv4 it takes effect immediately as the address and SNTP
server come in the same packet.

Tests:
 - Verify operation on dual-stack IPv4/IPv6:
   - DHCPv6 only network (no DHCPv4 server present)
   - DHCPv4 and DHCPv6 network
 - Verify operation on IPv4 only stack
 - Check SNTP restart with LwIP logging enabled
 - Verify time is requested and received via Wireshark
 - Verify system time is set

Signed-off-by: David J. Fiddes <D.J@fiddes.net>