### PR TITLE
Move lwip_cyclic_timers to PROGMEM

### DIFF
--- a/patches/cyclic-timers-to-pmem.patch
+++ b/patches/cyclic-timers-to-pmem.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/timeouts.c b/src/core/timeouts.c
+index f37acfec..71db3c7d 100644
+--- a/src/core/timeouts.c
++++ b/src/core/timeouts.c
+@@ -74,7 +74,7 @@
+ 
+ /** This array contains all stack-internal cyclic timers. To get the number of
+  * timers, use LWIP_ARRAYSIZE() */
+-const struct lwip_cyclic_timer lwip_cyclic_timers[] = {
++const struct lwip_cyclic_timer lwip_cyclic_timers[] __attribute__((section( "\".irom.text.lwip2\""))) = {
+ #if LWIP_TCP
+   /* The TCP timer is a special case: it does not have to run always and
+      is triggered to start from TCP using tcp_timer_needed() */


### PR DESCRIPTION
The two elements are 32-bit only (a pointer and a uint32), and it is
constant, so move to PROGMEM.

Frees 64 bytes of heap