### PR TITLE
Allow IPv4 and IPv6 DNS and SNTP server configured via DHCP to co-exist

### DIFF
--- a/patches/0002-sntp-Don-t-over-write-IPv6-NTP-server-when-processin.patch
+++ b/patches/0002-sntp-Don-t-over-write-IPv6-NTP-server-when-processin.patch
@@ -1,0 +1,105 @@
+From 450bf1739ef0e1bce97ed28c4ed2b74ae6cdb9ca Mon Sep 17 00:00:00 2001
+From: "David J. Fiddes" <D.J@fiddes.net>
+Date: Sun, 29 Sep 2019 17:46:17 +0100
+Subject: [PATCH] sntp: Don't over-write IPv6 NTP server when processing DHCP
+ updates
+
+Currently when a DHCP or DHCPv6 updates containing NTP
+server addresses is processed all existing NTP server addresses
+are wiped. This can lead to problems when there is intermittent
+connectivity to an NTP server over a given IP protocol. This
+changes DHCP update processing such that it only overwrites
+server addresses for the same protocol. It also does the same
+for IPv4 NTP server addresses when processing a DHCPv6 update.
+
+The logging for processing DHCP and DHCPv6 updates are now
+a bit more useful.
+
+Tests:
+ - On a network with DHCP and DHCPv6 configure diffiering
+   numbers (0-3) of NTP servers on each protocol. Ensure that
+   as updates are processed the list of 3 LWIP NTP servers is
+   updated as expected.
+ - On a network with intermittent IPv6 connectivity ensure that
+   with both IPv4 and IPv6 servers configured via DHCP that NTP
+   updates are requested over IPv4 even if it is not listed first.
+---
+ src/apps/sntp/sntp.c | 52 ++++++++++++++++++++++++++++----------------
+ 1 file changed, 33 insertions(+), 19 deletions(-)
+
+diff --git a/src/apps/sntp/sntp.c b/src/apps/sntp/sntp.c
+index a6c4ff07..494971ca 100644
+--- a/src/apps/sntp/sntp.c
++++ b/src/apps/sntp/sntp.c
+@@ -819,20 +819,28 @@ sntp_setserver(u8_t idx, const ip_addr_t *server)
+  * @param server IP address of the NTP server to set
+  */
+ void
+-dhcp_set_ntp_servers(u8_t num, const ip4_addr_t *server)
++dhcp_set_ntp_servers(u8_t num, const ip4_addr_t *servers)
+ {
+-  LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp: %s %u.%u.%u.%u as NTP server #%u via DHCP\n",
++  LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp: %s %u NTP server(s) via DHCP\n",
+                                  (sntp_set_servers_from_dhcp ? "Got" : "Rejected"),
+-                                 ip4_addr1(server), ip4_addr2(server), ip4_addr3(server), ip4_addr4(server), num));
++                                 num));
+   if (sntp_set_servers_from_dhcp && num) {
+-    u8_t i;
+-    for (i = 0; (i < num) && (i < SNTP_MAX_SERVERS); i++) {
+-      ip_addr_t addr;
+-      ip_addr_copy_from_ip4(addr, server[i]);
+-      sntp_setserver(i, &addr);
+-    }
+-    for (i = num; i < SNTP_MAX_SERVERS; i++) {
+-      sntp_setserver(i, NULL);
++    u8_t newidx = 0;
++    for (u8_t i = 0; i < SNTP_MAX_SERVERS; i++) {
++      const ip_addr_t* slotIp = sntp_getserver(i);
++      /* If we have an empty or IPv4 slot replace it with a new value from DHCP */
++      if (ip_addr_isany(slotIp) || IP_IS_V4(slotIp)) {
++        if (newidx < num) {
++          ip_addr_t addr;
++          ip_addr_copy_from_ip4(addr, servers[newidx]);
++          LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp: Adding server %s to slot %u\n",
++                                        ipaddr_ntoa(&addr), i ));
++          sntp_setserver(i, &addr);
++          newidx++;
++        } else {
++          sntp_setserver(i, NULL);
++        }
++      }
+     }
+   }
+ }
+@@ -852,14 +860,20 @@ dhcp6_set_ntp_servers(u8_t num_ntp_servers, ip_addr_t* ntp_server_addrs)
+                                  (sntp_set_servers_from_dhcp ? "Got" : "Rejected"),
+                                  num_ntp_servers));
+   if (sntp_set_servers_from_dhcp && num_ntp_servers) {
+-    u8_t i;
+-    for (i = 0; (i < num_ntp_servers) && (i < SNTP_MAX_SERVERS); i++) {
+-      LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp: NTP server %u: %s\n",
+-                                     i, ipaddr_ntoa(&ntp_server_addrs[i])));
+-      sntp_setserver(i, &ntp_server_addrs[i]);
+-    }
+-    for (i = num_ntp_servers; i < SNTP_MAX_SERVERS; i++) {
+-      sntp_setserver(i, NULL);
++    u8_t newidx = 0;
++    for (u8_t i = 0; i < SNTP_MAX_SERVERS; i++) {
++      const ip_addr_t* slotIp = sntp_getserver(i);
++      /* If we have an empty or IPv6 slot replace it with a new value from DHCPv6 */
++      if (ip_addr_isany(slotIp) || IP_IS_V6(slotIp)) {
++        if (newidx < num_ntp_servers) {
++          LWIP_DEBUGF(SNTP_DEBUG_TRACE, ("sntp: Adding server %s to slot %u\n",
++                                         ipaddr_ntoa(&ntp_server_addrs[newidx]), i));
++          sntp_setserver(i, &ntp_server_addrs[newidx]);
++          newidx++;
++        } else {
++          sntp_setserver(i, NULL);
++        }
++      }
+     }
+   }
+ }
+-- 
+2.21.0
+

--- a/patches/0003-dhcp-dhcp6-Ensure-that-DHCP-DHCPv6-DNS-server-update.patch
+++ b/patches/0003-dhcp-dhcp6-Ensure-that-DHCP-DHCPv6-DNS-server-update.patch
@@ -1,0 +1,96 @@
+From 71cd4d3ee5bd37faf66ce0b5efb94a4d585004da Mon Sep 17 00:00:00 2001
+From: "David J. Fiddes" <D.J@fiddes.net>
+Date: Thu, 3 Oct 2019 12:06:06 +0100
+Subject: [PATCH] dhcp/dhcp6:  Ensure that DHCP/DHCPv6 DNS server updates don't
+ overlap
+
+This change changes the DHCP and DHCPv6 DNS server option update
+processing so that both IPv4 and IPv6 servers can be held in the
+list of active DNS servers. Previously when a DHCP offer is processed
+the list of active DNS servers is replaced. This can lead to failed
+DNS resolution when there is a connectivity over one IP protocol
+but not over the other. This change improves the possibility of
+DNS resolution falling back to a working DNS server.
+
+Tests:
+ - On LWIP configured to use 2 DNS server entries. Configure DHCP and
+   DHCPv6 to have 0,1 or 2 DNS servers on each protcol. Ensure that
+   the list of active DNS servers reflects the network configuration.
+   In the case of overflow ensure that one protocol wins based on the
+   first processed DHCP response.
+ - On a network with intermittent IPv6 connectivity ensure that DNS
+   resolution continues to function as DHCP and DHCPv6 updates are
+   received.
+---
+ src/core/ipv4/dhcp.c  | 14 ++++++++++----
+ src/core/ipv6/dhcp6.c | 21 ++++++++++++---------
+ 2 files changed, 22 insertions(+), 13 deletions(-)
+
+diff --git a/src/core/ipv4/dhcp.c b/src/core/ipv4/dhcp.c
+index 6da9cd6b..70f944b9 100644
+--- a/src/core/ipv4/dhcp.c
++++ b/src/core/ipv4/dhcp.c
+@@ -625,6 +625,7 @@ dhcp_handle_ack(struct netif *netif, struct dhcp_msg *msg_in)
+ 
+ #if LWIP_DHCP_PROVIDE_DNS_SERVERS || LWIP_DHCP_GET_NTP_SRV
+   u8_t n;
++  u8_t idx;
+ #endif /* LWIP_DHCP_PROVIDE_DNS_SERVERS || LWIP_DHCP_GET_NTP_SRV */
+ #if LWIP_DHCP_GET_NTP_SRV
+   ip4_addr_t ntp_server_addrs[LWIP_DHCP_MAX_NTP_SERVERS];
+@@ -693,10 +694,15 @@ dhcp_handle_ack(struct netif *netif, struct dhcp_msg *msg_in)
+ 
+ #if LWIP_DHCP_PROVIDE_DNS_SERVERS
+   /* DNS servers */
+-  for (n = 0; (n < LWIP_DHCP_PROVIDE_DNS_SERVERS) && dhcp_option_given(dhcp, DHCP_OPTION_IDX_DNS_SERVER + n); n++) {
+-    ip_addr_t dns_addr;
+-    ip_addr_set_ip4_u32_val(dns_addr, lwip_htonl(dhcp_get_option_value(dhcp, DHCP_OPTION_IDX_DNS_SERVER + n)));
+-    dns_setserver(n, &dns_addr);
++  idx = 0;
++  for (n = 0; (n < LWIP_DHCP_PROVIDE_DNS_SERVERS) && dhcp_option_given(dhcp, DHCP_OPTION_IDX_DNS_SERVER + idx); n++) {
++    const ip_addr_t* dns_slot_ip = dns_getserver(n);
++    if (ip_addr_isany(dns_slot_ip) || IP_IS_V4(dns_slot_ip)) {
++      ip_addr_t dns_addr;
++      ip_addr_set_ip4_u32_val(dns_addr, lwip_htonl(dhcp_get_option_value(dhcp, DHCP_OPTION_IDX_DNS_SERVER + idx)));
++      dns_setserver(n, &dns_addr);
++      idx++;
++    }
+   }
+ #endif /* LWIP_DHCP_PROVIDE_DNS_SERVERS */
+ }
+diff --git a/src/core/ipv6/dhcp6.c b/src/core/ipv6/dhcp6.c
+index 002f688d..b18d6e9a 100644
+--- a/src/core/ipv6/dhcp6.c
++++ b/src/core/ipv6/dhcp6.c
+@@ -538,16 +538,19 @@ dhcp6_handle_config_reply(struct netif *netif, struct pbuf *p_msg_in)
+ 
+     ip_addr_set_zero_ip6(&dns_addr);
+     dns_addr6 = ip_2_ip6(&dns_addr);
+-    for (n = 0, idx = op_start; (idx < op_start + op_len) && (n < LWIP_DHCP6_PROVIDE_DNS_SERVERS);
+-         n++, idx += sizeof(struct ip6_addr_packed)) {
+-      u16_t copied = pbuf_copy_partial(p_msg_in, dns_addr6, sizeof(struct ip6_addr_packed), idx);
+-      if (copied != sizeof(struct ip6_addr_packed)) {
+-        /* pbuf length mismatch */
+-        return;
++    idx = op_start;
++    for (n = 0; (idx < op_start + op_len) && (n < LWIP_DHCP6_PROVIDE_DNS_SERVERS); n++ ) {
++      const ip_addr_t* dns_slot_ip = dns_getserver(n);
++      if (ip_addr_isany(dns_slot_ip) || IP_IS_V6(dns_slot_ip)) {
++        u16_t copied = pbuf_copy_partial(p_msg_in, dns_addr6, sizeof(struct ip6_addr_packed), idx);
++        if (copied != sizeof(struct ip6_addr_packed)) {
++          /* pbuf length mismatch */
++          return;
++        }
++        ip6_addr_assign_zone(dns_addr6, IP6_UNKNOWN, netif);
++        dns_setserver(n, &dns_addr);
++        idx += sizeof(struct ip6_addr_packed);
+       }
+-      ip6_addr_assign_zone(dns_addr6, IP6_UNKNOWN, netif);
+-      /* @todo: do we need a different offset than DHCP(v4)? */
+-      dns_setserver(n, &dns_addr);
+     }
+   }
+   /* @ todo: parse and set Domain Search List */
+-- 
+2.21.0
+


### PR DESCRIPTION
This change includes two LwIP patches which allow DHCP and DHCPv6 updates
containing DNS server and NTP server addresses to update the lists of
DNS and SNTP servers. This permits more reliable operation on a dual-stack
network.

Tests
 - Tested with the built-in IPv6.ino example on all LwIP v2 variants on
   a dual-stack IPv4/IPv6 network with DNS and NTP servers configured
   over DHCP/DHCPv6