### PR TITLE
Switch to LWIP_CHKSUM_ALGORITHM #3

### DIFF
--- a/glue-lwip/arduino/lwipopts.h
+++ b/glue-lwip/arduino/lwipopts.h
@@ -2274,6 +2274,12 @@
  * @{
  */
 /**
+ * LWIP_CHKSUM_ALGORITHM==3: Checksum algorithm fastest for ESP8266
+ */
+#if !defined LWIP_CHKSUM_ALGORITHM || defined __DOXYGEN__
+#define LWIP_CHKSUM_ALGORITHM           3 // 2
+#endif
+/**
  * LWIP_CHECKSUM_CTRL_PER_NETIF==1: Checksum generation/check can be enabled/disabled
  * per netif.
  * ATTENTION: if enabled, the CHECKSUM_GEN_* and CHECKSUM_CHECK_* defines must be enabled!


### PR DESCRIPTION
Are you sure you need it as an lwIP patch? It seems easier as an lwipopt. We can do patches too if you like.

Algorithm 3 takes about 40% less time per packet on xtensa lx106,
so switch from checksum algorithm # 2 (lwip default) to # 3.

 160MHz CPU, 1450B
46us - Algorithm 1
33us - Algorithm 2
19us - Algorithm 3

 80 MHz CPU, 1450B
92us - Algorithm 1
64us - Algorithm 2
37us - Algorithm 3