### PR TITLE
Allow to override toolchain path

### DIFF
--- a/Makefile.arduino
+++ b/Makefile.arduino
@@ -1,4 +1,4 @@
-PREFIX ?= $(abspath ../../../xtensa-lx106-elf)
+PREFIX ?= ../../../xtensa-lx106-elf
 
 %:
 	for v6 in 0 1; do \
@@ -15,7 +15,7 @@ PREFIX ?= $(abspath ../../../xtensa-lx106-elf)
 			LWIP_LIB=liblwip$$((2+4*v6))-$$mss$$featname.a \
 			LWIP_LIB_RELEASE=../../lib/liblwip$$((2+4*v6))-$$mss$$featname.a \
 			LWIP_INCLUDES_RELEASE=../include \
-			TOOLS=$(PREFIX)/bin/xtensa-lx106-elf- \
+			TOOLS=$(abspath $(wildcard $(PREFIX)))/bin/xtensa-lx106-elf- \
 			TCP_MSS=$$mss LWIP_FEATURES=$$feat LWIP_IPV6=$$v6 \
 			BUILD=build-$$mss$$featname-v$$((4+2*v6)) \
 			$@ ; \

--- a/Makefile.arduino
+++ b/Makefile.arduino
@@ -1,4 +1,4 @@
-PREFIX ?= ../../../xtensa-lx106-elf/
+PREFIX ?= $(abspath ../../../xtensa-lx106-elf)
 
 %:
 	for v6 in 0 1; do \

--- a/Makefile.arduino
+++ b/Makefile.arduino
@@ -1,3 +1,4 @@
+PREFIX ?= ../../../xtensa-lx106-elf/
 
 %:
 	for v6 in 0 1; do \
@@ -14,7 +15,7 @@
 			LWIP_LIB=liblwip$$((2+4*v6))-$$mss$$featname.a \
 			LWIP_LIB_RELEASE=../../lib/liblwip$$((2+4*v6))-$$mss$$featname.a \
 			LWIP_INCLUDES_RELEASE=../include \
-			TOOLS=../../../xtensa-lx106-elf/bin/xtensa-lx106-elf- \
+			TOOLS=$(PREFIX)/bin/xtensa-lx106-elf- \
 			TCP_MSS=$$mss LWIP_FEATURES=$$feat LWIP_IPV6=$$v6 \
 			BUILD=build-$$mss$$featname-v$$((4+2*v6)) \
 			$@ ; \

--- a/makefiles/Makefile.build-lwip2
+++ b/makefiles/Makefile.build-lwip2
@@ -81,4 +81,4 @@ endif
 
 clean:
 	rm -rf $(BUILD) $(LWIP_LIB) $(AUTO)
-	cd lwip2-src; rm -f src/.patched src/core/*.c.orig src/core/ipv6/*.c.orig; git checkout -- src;
+	cd lwip2-src; git checkout -f -- src; git clean -f -- src;

--- a/makefiles/Makefile.build-lwip2
+++ b/makefiles/Makefile.build-lwip2
@@ -52,7 +52,7 @@ $(LWIP_LIB):
 	make -f makefiles/Makefile.glue-esp BUILD=$(BUILD) V=$(V)
 	make -f makefiles/Makefile.glue target=$(target) BUILD=$(BUILD) TCP_MSS=$(TCP_MSS) LWIP_FEATURES=$(LWIP_FEATURES) LWIP_IPV6=$(LWIP_IPV6) V=$(V)
 ifeq ($(target),arduino)
-	make -C lwip2-src/src -f ../../makefiles/Makefile.lwip2 BUILD=../../$(BUILD) LWIP_LIB=../../$(LWIP_LIB) SDK=../../$(SDK) TOOLS=../../$(TOOLS) TCP_MSS=$(TCP_MSS) LWIP_FEATURES=$(LWIP_FEATURES) LWIP_IPV6=$(LWIP_IPV6) V=$(V)
+	make -C lwip2-src/src -f ../../makefiles/Makefile.lwip2 BUILD=../../$(BUILD) LWIP_LIB=../../$(LWIP_LIB) SDK=../../$(SDK) TCP_MSS=$(TCP_MSS) LWIP_FEATURES=$(LWIP_FEATURES) LWIP_IPV6=$(LWIP_IPV6) V=$(V)
 else
 	make -C lwip2-src/src -f ../../makefiles/Makefile.lwip2 BUILD=../../$(BUILD) LWIP_LIB=../../$(LWIP_LIB) TCP_MSS=$(TCP_MSS) LWIP_FEATURES=$(LWIP_FEATURES) LWIP_IPV6=$(LWIP_IPV6) V=$(V)
 endif


### PR DESCRIPTION
re: #41  
> Hardcode tools path in Makefile.arduino to TOOLS=~/.arduino15/packages/esp8266/tools/xtensa-lx106-elf-gcc/2.5.0-4-b40a506/bin/xtensa-lx106-elf-
Replace TOOLS=../../$(TOOLS) with TOOLS=$(TOOLS) in Makefile.build-lwip2

In case of PlatformIO, toolchain is in a custom dir:
```
$ env PREFIX=~/.platformio/packages/toolchain-xtensa/ make
```

---

IDF has a slightly different idea about pathing:
https://github.com/espressif/esp-idf/blob/f5b82c5b1f33f5287f9b5f1993594bf53755a4f2/Kconfig#L38-L45
I guess it can also be that way, essentially mapping TOOLS=$(PREFIX)