### PR TITLE
Only instantiate phy_capture in one spot

### DIFF
--- a/glue/gluedebug.h
+++ b/glue/gluedebug.h
@@ -38,9 +38,13 @@
 
 #define HAS_PHY_CAPTURE 1
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
-void (*phy_capture) (int netif_idx, const char* data, size_t len, int out, int success);
+extern void (*phy_capture) (int netif_idx, const char* data, size_t len, int out, int success);
+#ifdef __cplusplus
+}
+#endif
+
 
 /////////////////////////////////////////////////////////////////////////////
 #if ARDUINO


### PR DESCRIPTION
The gluedebug.h header was allocating an actual pointer to a function
each time it was included.  GCC10 barfs on this, but earlier versions
simply combine the identical allocations.

Make the function pointer an extern, not an instantiation, to fix GCC10.