### PR TITLE
 fix: the dhcp client behaviour is not standard compliant for DHCP cli… fa78077  …ents (RFC2131) (IDFGH-5139)

### DIFF
--- a/glue-lwip/arduino/lwipopts.h
+++ b/glue-lwip/arduino/lwipopts.h
@@ -3144,7 +3144,7 @@
  * options are at the end of a DHCP6 message.
  * Signature:\code{.c}
  *   void my_hook(struct netif *netif, struct dhcp6 *dhcp, u8_t state, struct dhcp6_msg *msg,
- *                u8_t msg_type, u16_t *options_len_ptr);
+ *                u8_t msg_type, u16_t *options_len_ptr, buffer_len);
  * \endcode
  * Arguments:
  * - netif: struct netif that the packet will be sent through
@@ -3154,6 +3154,7 @@
  * - msg_type: dhcp6 message type to be sent (u8_t)
  * - options_len_ptr: pointer to the current length of options in the dhcp6_msg "msg"
  *                    (must be increased when options are added!)
+ * - buffer_len: length of the buffer (u16_t)
  *
  * Options need to appended like this:
  *   u8_t *options = (u8_t *)(msg + 1);
@@ -3162,7 +3163,7 @@
  *   [...]
  */
 #if !defined LWIP_HOOK_DHCP6_APPEND_OPTIONS && defined __DOXYGEN__
-#define LWIP_HOOK_DHCP6_APPEND_OPTIONS(netif, dhcp6, state, msg, msg_type, options_len_ptr, max_len)
+#define LWIP_HOOK_DHCP6_APPEND_OPTIONS(netif, dhcp6, state, msg, msg_type, options_len_ptr, buffer_len)
 #endif
 
 /**

--- a/glue-lwip/arduino/lwipopts.h
+++ b/glue-lwip/arduino/lwipopts.h
@@ -2750,7 +2750,7 @@
  * Declare your hook function prototypes in there, you may also \#include all headers
  * providing data types that are need in this file.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_FILENAME && defined __DOXYGEN__
 #define LWIP_HOOK_FILENAME "path/to/my/lwip_hooks.h"
 #endif
 
@@ -2775,7 +2775,7 @@
  * Return value:
  * - the 32-bit Initial Sequence Number to use for the new TCP connection.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_TCP_ISN && defined __DOXYGEN__
 #define LWIP_HOOK_TCP_ISN(local_ip, local_port, remote_ip, remote_port)
 #endif
 
@@ -2805,7 +2805,7 @@
  * ATTENTION: don't call any tcp api functions that might change tcp state (pcb
  * state or any pcb lists) from this callback!
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_TCP_INPACKET_PCB && defined __DOXYGEN__
 #define LWIP_HOOK_TCP_INPACKET_PCB(pcb, hdr, optlen, opt1len, opt2, p)
 #endif
 
@@ -2827,7 +2827,7 @@
  * ATTENTION: don't call any tcp api functions that might change tcp state (pcb
  * state or any pcb lists) from this callback!
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_TCP_OUT_TCPOPT_LENGTH && defined __DOXYGEN__
 #define LWIP_HOOK_TCP_OUT_TCPOPT_LENGTH(pcb, internal_len)
 #endif
 
@@ -2851,7 +2851,7 @@
  * ATTENTION: don't call any tcp api functions that might change tcp state (pcb
  * state or any pcb lists) from this callback!
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_TCP_OUT_ADD_TCPOPTS && defined __DOXYGEN__
 #define LWIP_HOOK_TCP_OUT_ADD_TCPOPTS(p, hdr, pcb, opts)
 #endif
 
@@ -2870,7 +2870,7 @@
  * If the hook consumed the packet, 'pbuf' is in the responsibility of the hook
  * (i.e. free it when done).
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP4_INPUT && defined __DOXYGEN__
 #define LWIP_HOOK_IP4_INPUT(pbuf, input_netif)
 #endif
 
@@ -2886,7 +2886,7 @@
  * - the destination netif
  * - NULL if no destination netif is found. In that case, ip_route() continues as normal.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP4_ROUTE && defined __DOXYGEN__
 #define LWIP_HOOK_IP4_ROUTE()
 #endif
 
@@ -2903,7 +2903,7 @@
  * - the destination netif
  * - NULL if no destination netif is found. In that case, ip_route() continues as normal.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP4_ROUTE_SRC && defined __DOXYGEN__
 #define LWIP_HOOK_IP4_ROUTE_SRC(src, dest)
 #endif
 
@@ -2924,7 +2924,7 @@
  * - 0: don't forward
  * - -1: no decision. In that case, ip4_canforward() continues as normal.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP4_CANFORWARD && defined __DOXYGEN__
 #define LWIP_HOOK_IP4_CANFORWARD(src, dest)
 #endif
 
@@ -2946,7 +2946,7 @@
  * LWIP_HOOK_IP4_ROUTE(). The actual routing/gateway table implementation is
  * not part of lwIP but can e.g. be hidden in the netif's state argument.
 */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_ETHARP_GET_GW && defined __DOXYGEN__
 #define LWIP_HOOK_ETHARP_GET_GW(netif, dest)
 #endif
 
@@ -2965,7 +2965,7 @@
  * If the hook consumed the packet, 'pbuf' is in the responsibility of the hook
  * (i.e. free it when done).
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP6_INPUT && defined __DOXYGEN__
 #define LWIP_HOOK_IP6_INPUT(pbuf, input_netif)
 #endif
 
@@ -2982,7 +2982,7 @@
  * - the destination netif
  * - NULL if no destination netif is found. In that case, ip6_route() continues as normal.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP6_ROUTE && defined __DOXYGEN__
 #define LWIP_HOOK_IP6_ROUTE(src, dest)
 #endif
 
@@ -3004,7 +3004,7 @@
  * LWIP_HOOK_IP6_ROUTE(). The actual routing/gateway table implementation is
  * not part of lwIP but can e.g. be hidden in the netif's state argument.
 */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_ND6_GET_GW && defined __DOXYGEN__
 #define LWIP_HOOK_ND6_GET_GW(netif, dest)
 #endif
 
@@ -3022,7 +3022,7 @@
  * - 0: Packet must be dropped.
  * - != 0: Packet must be accepted.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_VLAN_CHECK && defined __DOXYGEN__
 #define LWIP_HOOK_VLAN_CHECK(netif, eth_hdr, vlan_hdr)
 #endif
 
@@ -3046,7 +3046,7 @@
  * - &lt;0: Packet shall not contain VLAN header.
  * - 0 &lt;= return value &lt;= 0xFFFF: Packet shall contain VLAN header. Return value is prio_vid in host byte order.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_VLAN_SET && defined __DOXYGEN__
 #define LWIP_HOOK_VLAN_SET(netif, p, src, dst, eth_type)
 #endif
 
@@ -3057,7 +3057,7 @@
  *   void my_hook(memp_t type);
  * \endcode
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_MEMP_AVAILABLE && defined __DOXYGEN__
 #define LWIP_HOOK_MEMP_AVAILABLE(memp_t_type)
 #endif
 
@@ -3076,7 +3076,7 @@
  *
  * Payload points to ethernet header!
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_UNKNOWN_ETH_PROTOCOL && defined __DOXYGEN__
 #define LWIP_HOOK_UNKNOWN_ETH_PROTOCOL(pbuf, netif) lwip_unhandled_packet((pbuf), (netif))
 #endif
 
@@ -3105,7 +3105,7 @@
  *   msg->options[(*options_len_ptr)++] = &lt;option_bytes&gt;;
  *   [...]
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_DHCP_APPEND_OPTIONS && defined __DOXYGEN__
 #define LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, state, msg, msg_type, options_len_ptr)
 #endif
 
@@ -3133,7 +3133,7 @@
  *  u8_t buf[32];
  *  u8_t *ptr = (u8_t*)pbuf_get_contiguous(p, buf, sizeof(buf), LWIP_MIN(option_len, sizeof(buf)), offset);
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_DHCP_PARSE_OPTION && defined __DOXYGEN__
 //#define LWIP_HOOK_DHCP_PARSE_OPTION(netif, dhcp, state, msg, msg_type, option, len, pbuf, offset)
 #endif
 
@@ -3161,7 +3161,7 @@
  *   options[(*options_len_ptr)++] = &lt;option_data&gt;;
  *   [...]
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_DHCP6_APPEND_OPTIONS && defined __DOXYGEN__
 #define LWIP_HOOK_DHCP6_APPEND_OPTIONS(netif, dhcp6, state, msg, msg_type, options_len_ptr, max_len)
 #endif
 
@@ -3184,7 +3184,7 @@
  * - 0: Hook has not consumed the option, code continues as normal (to internal options)
  * - != 0: Hook has consumed the option, 'err' is returned
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_SOCKETS_SETSOCKOPT && defined __DOXYGEN__
 #define LWIP_HOOK_SOCKETS_SETSOCKOPT(s, sock, level, optname, optval, optlen, err)
 #endif
 
@@ -3207,7 +3207,7 @@
  * - 0: Hook has not consumed the option, code continues as normal (to internal options)
  * - != 0: Hook has consumed the option, 'err' is returned
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_SOCKETS_GETSOCKOPT && defined __DOXYGEN__
 #define LWIP_HOOK_SOCKETS_GETSOCKOPT(s, sock, level, optname, optval, optlen, err)
 #endif
 
@@ -3230,7 +3230,7 @@
  * err must also be checked to determine if the hook consumed the query, but
  * the query failed
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_NETCONN_EXTERNAL_RESOLVE && defined __DOXYGEN__
 #define LWIP_HOOK_NETCONN_EXTERNAL_RESOLVE(name, addr, addrtype, err)
 #endif
 /**

--- a/glue-lwip/lwip-git.c
+++ b/glue-lwip/lwip-git.c
@@ -196,6 +196,7 @@ err_glue_t esp2glue_dhcp_start (int netif_idx)
 	// calls netif_sta_status_callback() - if applicable (STA)
 	netif_set_up(&netif_git[netif_idx]);
 
+#if LWIP_NETIF_HOSTNAME
 	// Update to latest esp hostname before starting dhcp client,
 	// 	because this name is provided to the dhcp server.
 	// Until proven wrong, dhcp client is the only code
@@ -205,6 +206,7 @@ err_glue_t esp2glue_dhcp_start (int netif_idx)
 	// XXX to check: is wifi_station_get_hostname()
 	// 	returning a const pointer once _set_hostname is called?
 	netif_git[netif_idx].hostname = wifi_station_get_hostname();
+#endif
 
 	err_t err = dhcp_start(&netif_git[netif_idx]);
 #if LWIP_IPV6 && LWIP_IPV6_DHCP6_STATELESS
@@ -352,7 +354,9 @@ static void netif_init_common (struct netif* netif)
 	netif->ip6_autoconfig_enabled = 1;
 #endif
 	
+#if LWIP_NETIF_HOSTNAME
 	netif->hostname = wifi_station_get_hostname();
+#endif
 	netif->chksum_flags = NETIF_CHECKSUM_ENABLE_ALL;
 	// netif->mtu given by glue
 }
@@ -409,7 +413,9 @@ void esp2glue_netif_update (int netif_idx, uint32_t ip, uint32_t mask, uint32_t 
 		netif->flags &= ~NETIF_FLAG_UP;
 
 	netif->mtu = mtu;
+#if LWIP_NETIF_HOSTNAME
 	netif->hostname = wifi_station_get_hostname();
+#endif
 	ip4_addr_t aip = { ip }, amask = { mask }, agw = { gw };
 	netif_set_addr(&netif_git[netif_idx], &aip, &amask, &agw);
 	esp2glue_netif_set_up1down0(netif_idx, 1);

--- a/glue-lwip/open/lwipopts.h
+++ b/glue-lwip/open/lwipopts.h
@@ -3138,7 +3138,7 @@
  * options are at the end of a DHCP6 message.
  * Signature:\code{.c}
  *   void my_hook(struct netif *netif, struct dhcp6 *dhcp, u8_t state, struct dhcp6_msg *msg,
- *                u8_t msg_type, u16_t *options_len_ptr);
+ *                u8_t msg_type, u16_t *options_len_ptr, buffer_len);
  * \endcode
  * Arguments:
  * - netif: struct netif that the packet will be sent through
@@ -3148,6 +3148,7 @@
  * - msg_type: dhcp6 message type to be sent (u8_t)
  * - options_len_ptr: pointer to the current length of options in the dhcp6_msg "msg"
  *                    (must be increased when options are added!)
+ * - buffer_len: length of the buffer (u16_t)
  *
  * Options need to appended like this:
  *   u8_t *options = (u8_t *)(msg + 1);
@@ -3156,7 +3157,7 @@
  *   [...]
  */
 #if !defined LWIP_HOOK_DHCP6_APPEND_OPTIONS && defined __DOXYGEN__
-#define LWIP_HOOK_DHCP6_APPEND_OPTIONS(netif, dhcp6, state, msg, msg_type, options_len_ptr, max_len)
+#define LWIP_HOOK_DHCP6_APPEND_OPTIONS(netif, dhcp6, state, msg, msg_type, options_len_ptr, buffer_len)
 #endif
 
 /**

--- a/glue-lwip/open/lwipopts.h
+++ b/glue-lwip/open/lwipopts.h
@@ -2744,7 +2744,7 @@
  * Declare your hook function prototypes in there, you may also \#include all headers
  * providing data types that are need in this file.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_FILENAME && defined __DOXYGEN__
 #define LWIP_HOOK_FILENAME "path/to/my/lwip_hooks.h"
 #endif
 
@@ -2769,7 +2769,7 @@
  * Return value:
  * - the 32-bit Initial Sequence Number to use for the new TCP connection.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_TCP_ISN && defined __DOXYGEN__
 #define LWIP_HOOK_TCP_ISN(local_ip, local_port, remote_ip, remote_port)
 #endif
 
@@ -2799,7 +2799,7 @@
  * ATTENTION: don't call any tcp api functions that might change tcp state (pcb
  * state or any pcb lists) from this callback!
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_TCP_INPACKET_PCB && defined __DOXYGEN__
 #define LWIP_HOOK_TCP_INPACKET_PCB(pcb, hdr, optlen, opt1len, opt2, p)
 #endif
 
@@ -2821,7 +2821,7 @@
  * ATTENTION: don't call any tcp api functions that might change tcp state (pcb
  * state or any pcb lists) from this callback!
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_TCP_OUT_TCPOPT_LENGTH && defined __DOXYGEN__
 #define LWIP_HOOK_TCP_OUT_TCPOPT_LENGTH(pcb, internal_len)
 #endif
 
@@ -2845,7 +2845,7 @@
  * ATTENTION: don't call any tcp api functions that might change tcp state (pcb
  * state or any pcb lists) from this callback!
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_TCP_OUT_ADD_TCPOPTS && defined __DOXYGEN__
 #define LWIP_HOOK_TCP_OUT_ADD_TCPOPTS(p, hdr, pcb, opts)
 #endif
 
@@ -2864,7 +2864,7 @@
  * If the hook consumed the packet, 'pbuf' is in the responsibility of the hook
  * (i.e. free it when done).
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP4_INPUT && defined __DOXYGEN__
 #define LWIP_HOOK_IP4_INPUT(pbuf, input_netif)
 #endif
 
@@ -2880,7 +2880,7 @@
  * - the destination netif
  * - NULL if no destination netif is found. In that case, ip_route() continues as normal.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP4_ROUTE && defined __DOXYGEN__
 #define LWIP_HOOK_IP4_ROUTE()
 #endif
 
@@ -2897,7 +2897,7 @@
  * - the destination netif
  * - NULL if no destination netif is found. In that case, ip_route() continues as normal.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP4_ROUTE_SRC && defined __DOXYGEN__
 #define LWIP_HOOK_IP4_ROUTE_SRC(src, dest)
 #endif
 
@@ -2918,7 +2918,7 @@
  * - 0: don't forward
  * - -1: no decision. In that case, ip4_canforward() continues as normal.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP4_CANFORWARD && defined __DOXYGEN__
 #define LWIP_HOOK_IP4_CANFORWARD(src, dest)
 #endif
 
@@ -2940,7 +2940,7 @@
  * LWIP_HOOK_IP4_ROUTE(). The actual routing/gateway table implementation is
  * not part of lwIP but can e.g. be hidden in the netif's state argument.
 */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_ETHARP_GET_GW && defined __DOXYGEN__
 #define LWIP_HOOK_ETHARP_GET_GW(netif, dest)
 #endif
 
@@ -2959,7 +2959,7 @@
  * If the hook consumed the packet, 'pbuf' is in the responsibility of the hook
  * (i.e. free it when done).
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP6_INPUT && defined __DOXYGEN__
 #define LWIP_HOOK_IP6_INPUT(pbuf, input_netif)
 #endif
 
@@ -2976,7 +2976,7 @@
  * - the destination netif
  * - NULL if no destination netif is found. In that case, ip6_route() continues as normal.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_IP6_ROUTE && defined __DOXYGEN__
 #define LWIP_HOOK_IP6_ROUTE(src, dest)
 #endif
 
@@ -2998,7 +2998,7 @@
  * LWIP_HOOK_IP6_ROUTE(). The actual routing/gateway table implementation is
  * not part of lwIP but can e.g. be hidden in the netif's state argument.
 */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_ND6_GET_GW && defined __DOXYGEN__
 #define LWIP_HOOK_ND6_GET_GW(netif, dest)
 #endif
 
@@ -3016,7 +3016,7 @@
  * - 0: Packet must be dropped.
  * - != 0: Packet must be accepted.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_VLAN_CHECK && defined __DOXYGEN__
 #define LWIP_HOOK_VLAN_CHECK(netif, eth_hdr, vlan_hdr)
 #endif
 
@@ -3040,7 +3040,7 @@
  * - &lt;0: Packet shall not contain VLAN header.
  * - 0 &lt;= return value &lt;= 0xFFFF: Packet shall contain VLAN header. Return value is prio_vid in host byte order.
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_VLAN_SET && defined __DOXYGEN__
 #define LWIP_HOOK_VLAN_SET(netif, p, src, dst, eth_type)
 #endif
 
@@ -3051,7 +3051,7 @@
  *   void my_hook(memp_t type);
  * \endcode
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_MEMP_AVAILABLE && defined __DOXYGEN__
 #define LWIP_HOOK_MEMP_AVAILABLE(memp_t_type)
 #endif
 
@@ -3070,7 +3070,7 @@
  *
  * Payload points to ethernet header!
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_UNKNOWN_ETH_PROTOCOL && defined __DOXYGEN__
 #define LWIP_HOOK_UNKNOWN_ETH_PROTOCOL(pbuf, netif) lwip_unhandled_packet((pbuf), (netif))
 #endif
 
@@ -3099,7 +3099,7 @@
  *   msg->options[(*options_len_ptr)++] = &lt;option_bytes&gt;;
  *   [...]
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_DHCP_APPEND_OPTIONS && defined __DOXYGEN__
 #define LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, state, msg, msg_type, options_len_ptr)
 #endif
 
@@ -3127,7 +3127,7 @@
  *  u8_t buf[32];
  *  u8_t *ptr = (u8_t*)pbuf_get_contiguous(p, buf, sizeof(buf), LWIP_MIN(option_len, sizeof(buf)), offset);
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_DHCP_PARSE_OPTION && defined __DOXYGEN__
 #define LWIP_HOOK_DHCP_PARSE_OPTION(netif, dhcp, state, msg, msg_type, option, len, pbuf, offset)
 #endif
 
@@ -3155,7 +3155,7 @@
  *   options[(*options_len_ptr)++] = &lt;option_data&gt;;
  *   [...]
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_DHCP6_APPEND_OPTIONS && defined __DOXYGEN__
 #define LWIP_HOOK_DHCP6_APPEND_OPTIONS(netif, dhcp6, state, msg, msg_type, options_len_ptr, max_len)
 #endif
 
@@ -3178,7 +3178,7 @@
  * - 0: Hook has not consumed the option, code continues as normal (to internal options)
  * - != 0: Hook has consumed the option, 'err' is returned
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_SOCKETS_SETSOCKOPT && defined __DOXYGEN__
 #define LWIP_HOOK_SOCKETS_SETSOCKOPT(s, sock, level, optname, optval, optlen, err)
 #endif
 
@@ -3201,7 +3201,7 @@
  * - 0: Hook has not consumed the option, code continues as normal (to internal options)
  * - != 0: Hook has consumed the option, 'err' is returned
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_SOCKETS_GETSOCKOPT && defined __DOXYGEN__
 #define LWIP_HOOK_SOCKETS_GETSOCKOPT(s, sock, level, optname, optval, optlen, err)
 #endif
 
@@ -3224,7 +3224,7 @@
  * err must also be checked to determine if the hook consumed the query, but
  * the query failed
  */
-#ifdef __DOXYGEN__
+#if !defined LWIP_HOOK_NETCONN_EXTERNAL_RESOLVE && defined __DOXYGEN__
 #define LWIP_HOOK_NETCONN_EXTERNAL_RESOLVE(name, addr, addrtype, err)
 #endif
 /**

--- a/makefiles/Makefile.defs
+++ b/makefiles/Makefile.defs
@@ -26,3 +26,4 @@ OD			= $(TOOLS)objdump
 BUILD			?= build
 BUILD_FLAGS += -Wall -Wextra -c -Os -g -free -fipa-pta -Wpointer-arith -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -falign-functions=4 -MMD -ffunction-sections -fdata-sections
 BUILD_DEFINES = -D__ets__ -DICACHE_FLASH -U__STRICT_ANSI__ -DLWIP_OPEN_SRC -DLWIP_BUILD -DUSE_OPTIMIZE_PRINTF -DTARGET=$(target) -D$(DEFINE_TARGET)=1 -DTCP_MSS=$(TCP_MSS) -DLWIP_FEATURES=$(LWIP_FEATURES) -DLWIP_IPV6=$(LWIP_IPV6)
+BUILD_DEFINES += -DLWIP_NETIF_HOSTNAME=$(LWIP_FEATURES) -DESP_DHCP=$(LWIP_FEATURES)

--- a/patches/dhcpv4-clientid-fix-v1.patch
+++ b/patches/dhcpv4-clientid-fix-v1.patch
@@ -1,0 +1,134 @@
+--- a/src/core/ipv4/dhcp.c	2021-07-24 17:06:23.000000000 +0200
++++ b/src/core/ipv4/dhcp.c	2021-07-24 16:22:53.000000000 +0200
+@@ -218,6 +218,9 @@
+ #if LWIP_NETIF_HOSTNAME
+ static u16_t dhcp_option_hostname(u16_t options_out_len, u8_t *options, struct netif *netif);
+ #endif /* LWIP_NETIF_HOSTNAME */
++#if ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID
++static u16_t dhcp_option_client_id(struct netif *netif, struct dhcp_msg *msg_out, u16_t options_out_len);
++#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID */
+ /* always add the DHCP options trailer to end and pad */
+ static void dhcp_option_trailer(u16_t options_out_len, u8_t *options, struct pbuf *p_out);
+ 
+@@ -390,6 +393,10 @@
+     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_REQUESTED_IP, 4);
+     options_out_len = dhcp_option_long(options_out_len, msg_out->options, lwip_ntohl(ip4_addr_get_u32(&dhcp->offered_ip_addr)));
+ 
++#if ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID
++    options_out_len = dhcp_option_client_id(netif, msg_out, options_out_len);
++#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID */
++
+     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_SERVER_ID, 4);
+     options_out_len = dhcp_option_long(options_out_len, msg_out->options, lwip_ntohl(ip4_addr_get_u32(ip_2_ip4(&dhcp->server_ip_addr))));
+ 
+@@ -955,6 +962,10 @@
+     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_REQUESTED_IP, 4);
+     options_out_len = dhcp_option_long(options_out_len, msg_out->options, lwip_ntohl(ip4_addr_get_u32(&dhcp->offered_ip_addr)));
+ 
++#if ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID
++    options_out_len = dhcp_option_client_id(netif, msg_out, options_out_len);
++#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID */
++
+     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_BACKING_OFF, msg_out, DHCP_DECLINE, &options_out_len);
+     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
+ 
+@@ -1006,6 +1017,16 @@
+     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_MAX_MSG_SIZE, DHCP_OPTION_MAX_MSG_SIZE_LEN);
+     options_out_len = dhcp_option_short(options_out_len, msg_out->options, DHCP_MAX_MSG_LEN(netif));
+ 
++#if ESP_DHCP
++#if LWIP_NETIF_HOSTNAME
++    options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
++#endif /* LWIP NETIF HOSTNAME */
++
++#if !ESP_DHCP_DISABLE_CLIENT_ID
++    options_out_len = dhcp_option_client_id(netif, msg_out, options_out_len);
++#endif /* !ESP_DHCP_DISABLE_CLIENT_ID */
++#endif/* ESP_DHCP */
++
+     options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_PARAMETER_REQUEST_LIST, LWIP_ARRAYSIZE(dhcp_discover_request_options));
+     for (i = 0; i < LWIP_ARRAYSIZE(dhcp_discover_request_options); i++) {
+       options_out_len = dhcp_option_byte(options_out_len, msg_out->options, dhcp_discover_request_options[i]);
+@@ -1182,6 +1203,10 @@
+     options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
+ #endif /* LWIP_NETIF_HOSTNAME */
+ 
++#if ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID
++    options_out_len = dhcp_option_client_id(netif, msg_out, options_out_len);
++#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID */
++
+     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_RENEWING, msg_out, DHCP_REQUEST, &options_out_len);
+     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
+ 
+@@ -1237,6 +1262,10 @@
+     options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
+ #endif /* LWIP_NETIF_HOSTNAME */
+ 
++#if ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID
++    options_out_len = dhcp_option_client_id(netif, msg_out, options_out_len);
++#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID */
++
+     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_REBINDING, msg_out, DHCP_DISCOVER, &options_out_len);
+     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
+ 
+@@ -1294,6 +1323,10 @@
+     options_out_len = dhcp_option_hostname(options_out_len, msg_out->options, netif);
+ #endif /* LWIP_NETIF_HOSTNAME */
+ 
++#if ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID
++    options_out_len = dhcp_option_client_id(netif, msg_out, options_out_len);
++#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID */
++
+     LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, DHCP_STATE_REBOOTING, msg_out, DHCP_REQUEST, &options_out_len);
+     dhcp_option_trailer(options_out_len, msg_out->options, p_out);
+ 
+@@ -1361,6 +1394,10 @@
+       options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_SERVER_ID, 4);
+       options_out_len = dhcp_option_long(options_out_len, msg_out->options, lwip_ntohl(ip4_addr_get_u32(ip_2_ip4(&server_ip_addr))));
+ 
++#if ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID
++      options_out_len = dhcp_option_client_id(netif, msg_out, options_out_len);
++#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID */
++
+       LWIP_HOOK_DHCP_APPEND_OPTIONS(netif, dhcp, dhcp->state, msg_out, DHCP_RELEASE, &options_out_len);
+       dhcp_option_trailer(options_out_len, msg_out->options, p_out);
+ 
+@@ -1499,6 +1536,21 @@
+ }
+ #endif /* LWIP_NETIF_HOSTNAME */
+ 
++#if ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID
++static u16_t
++dhcp_option_client_id(struct netif *netif, struct dhcp_msg *msg_out, u16_t options_out_len)
++{
++  size_t i;
++  options_out_len = dhcp_option(options_out_len, msg_out->options, DHCP_OPTION_CLIENT_ID, DHCP_OPTION_CLIENT_ID_MAC_LEN);
++  options_out_len = dhcp_option_byte(options_out_len, msg_out->options, DHCP_OPTION_CLIENT_ID_MAC);
++  for (i = 0; i < netif->hwaddr_len; i++) {
++    options_out_len = dhcp_option_byte(options_out_len, msg_out->options, netif->hwaddr[i]);
++  }
++  return options_out_len;
++}
++#endif /* ESP_DHCP && !ESP_DHCP_DISABLE_CLIENT_ID */
++
++
+ /**
+  * Extract the DHCP message and the DHCP options.
+  *
+--- a/src/include/lwip/prot/dhcp.h	2021-07-24 17:24:44.000000000 +0200
++++ b/src/include/lwip/prot/dhcp.h	2021-07-24 16:55:53.000000000 +0200
+@@ -170,6 +170,14 @@
+ #define DHCP_OVERLOAD_SNAME         2
+ #define DHCP_OVERLOAD_SNAME_FILE    3
+ 
++/* DHCP OPTION 61 TYPE */
++#if ESP_DHCP
++#define DHCP_OPTION_CLIENT_ID_MAC   0x01
++#define DHCP_OPTION_CLIENT_ID_DUID  0x02
++#define DHCP_OPTION_CLIENT_ID_IAID  0xff
++
++#define DHCP_OPTION_CLIENT_ID_MAC_LEN   7
++#endif
+ 
+ #ifdef __cplusplus
+ }


### PR DESCRIPTION
LWIP_HOOKS_* was defined as soon as __DOXYGEN__ is defined. 
Now we keep the custom hooks even if __DOXYGEN__ is defined. 