### PR TITLE
default interface selected when gateway is valid

### DIFF
--- a/glue-lwip/lwip-git.c
+++ b/glue-lwip/lwip-git.c
@@ -322,8 +322,8 @@ static void netif_sta_status_callback (struct netif* netif)
 	if (   netif->flags & NETIF_FLAG_UP
 	    && netif == netif_sta)
 	{
-		if ((netif_default == NULL || netif_default == netif_ap) && !ip_addr_islinklocal(&netif->ip_addr)) {
-			// STA interface can be our default route if none or AP is currently set
+		if ((netif_default == NULL || netif_default == netif_ap) && !ip_addr_isany(&netif->gw)) {
+			// STA interface can be our default route if there is currently none and if there is a valid gw address
 			netif_set_default(netif);
 		}
 

--- a/glue-lwip/lwip-git.c
+++ b/glue-lwip/lwip-git.c
@@ -322,7 +322,7 @@ static void netif_sta_status_callback (struct netif* netif)
 	if (   netif->flags & NETIF_FLAG_UP
 	    && netif == netif_sta)
 	{
-		if (netif_default == NULL || netif_default == netif_ap) {
+		if ((netif_default == NULL || netif_default == netif_ap) && !ip_addr_islinklocal(&netif->ip_addr)) {
 			// STA interface can be our default route if none or AP is currently set
 			netif_set_default(netif);
 		}

--- a/glue-lwip/lwip-git.c
+++ b/glue-lwip/lwip-git.c
@@ -322,9 +322,11 @@ static void netif_sta_status_callback (struct netif* netif)
 	if (   netif->flags & NETIF_FLAG_UP
 	    && netif == netif_sta)
 	{
-		// this is our default route
-		netif_set_default(netif);
-			
+		if (netif_default == nullptr || netif_default == netif_ap) {
+			// STA interface can be our default route if none or AP is currently set
+			netif_set_default(netif);
+		}
+
 		// If we have a valid address of any type restart SNTP
 		bool valid_address = ip_2_ip4(&netif->ip_addr)->addr;
 

--- a/glue-lwip/lwip-git.c
+++ b/glue-lwip/lwip-git.c
@@ -322,7 +322,7 @@ static void netif_sta_status_callback (struct netif* netif)
 	if (   netif->flags & NETIF_FLAG_UP
 	    && netif == netif_sta)
 	{
-		if (netif_default == nullptr || netif_default == netif_ap) {
+		if (netif_default == NULL || netif_default == netif_ap) {
 			// STA interface can be our default route if none or AP is currently set
 			netif_set_default(netif);
 		}

--- a/glue-lwip/lwip-git.c
+++ b/glue-lwip/lwip-git.c
@@ -312,6 +312,7 @@ void esp2glue_netif_set_default (int netif_idx)
 static void netif_sta_status_callback (struct netif* netif)
 {
 	// address can be set or reset/any (=0)
+	// netif is netif_sta
 
 	uprint(DBG "netif status callback:\n");
 	new_display_netif(netif);
@@ -319,10 +320,9 @@ static void netif_sta_status_callback (struct netif* netif)
 	// tell ESP that link is updated
 	glue2esp_ifupdown(netif->num, ip_2_ip4(&netif->ip_addr)->addr, ip_2_ip4(&netif->netmask)->addr, ip_2_ip4(&netif->gw)->addr);
 
-	if (   netif->flags & NETIF_FLAG_UP
-	    && netif == netif_sta)
+	if (netif->flags & NETIF_FLAG_UP)
 	{
-		if ((netif_default == NULL || netif_default == netif_ap) && !ip_addr_isany(&netif->gw)) {
+		if ((netif_default == NULL) && !ip_addr_isany(&netif->gw)) {
 			// STA interface can be our default route if there is currently none and if there is a valid gw address
 			netif_set_default(netif);
 		}
@@ -341,6 +341,11 @@ static void netif_sta_status_callback (struct netif* netif)
 			sntp_stop();
 			sntp_init();
 		}
+	}
+	else
+	{
+	    if (netif_default == netif)
+	        netif_set_default(NULL);
 	}
 }
 


### PR DESCRIPTION
When interface STA was becoming "UP", it was selected as default interface.
Now it is selected as default interface (= the way out for unknown destination address) only when
there is no default interface, or when default interface is AP (cannot be the way out),
*and* the STA interface address is not private.

This PR is included in https://github.com/esp8266/Arduino/pull/8319
which embeds a similar test for ethernet interfaces.