### PR TITLE
u32/s32 as an int instead of a long

### DIFF
--- a/glue-esp/lwip-1.4-arduino/include/arch/cc.h
+++ b/glue-esp/lwip-1.4-arduino/include/arch/cc.h
@@ -55,8 +55,8 @@ typedef unsigned   char    u8_t;
 typedef signed     char    s8_t;
 typedef unsigned   short   u16_t;
 typedef signed     short   s16_t;
-typedef unsigned   long    u32_t;
-typedef signed     long    s32_t;
+typedef unsigned   int     u32_t;
+typedef signed     int     s32_t;
 typedef unsigned long   mem_ptr_t;
 
 #define S16_F "d"


### PR DESCRIPTION
Define u32 as an int so it is 32 bits on intel 64 bits arch when compiling arduino core on host