### PR TITLE
make `sys_now()` an always inlined function

### DIFF
--- a/glue-lwip/arch/cc.h
+++ b/glue-lwip/arch/cc.h
@@ -85,7 +85,16 @@ typedef uint32_t sys_prot_t;
 ///////////////////////////////
 //// MISSING 
 
-#define sys_now millis		// arduino wire millis() definition returns 32 bits like sys_now() does
+// transparent wrapper for millis()'s return value type from ulong to u32
+#if __cplusplus
+extern "C" {
+#endif
+extern unsigned long millis();
+inline __attribute__((always_inline)) u32_t sys_now () { return (u32_t)millis(); }
+#if __cplusplus
+}
+#endif
+
 #define LWIP_RAND r_rand	// old lwip uses this useful undocumented function
 #define IPSTR "%d.%d.%d.%d"
 #define IP2STR(ipaddr) ip4_addr1_16(ipaddr), \

--- a/glue-lwip/arch/sys_arch.h
+++ b/glue-lwip/arch/sys_arch.h
@@ -1,5 +1,0 @@
-
-#ifndef MYSYSARCH_H
-#define MYSYSARCH_H
-
-#endif // MYSYSARCH_H

--- a/makefiles/Makefile.build-lwip2
+++ b/makefiles/Makefile.build-lwip2
@@ -49,6 +49,7 @@ $(LWIP_LIB_RELEASE): $(LWIP_LIB)
 
 .PHONY: $(LWIP_LIB)
 $(LWIP_LIB):
+	make -C lwip2-src/src -f ../../makefiles/Makefile.patches
 	make -f makefiles/Makefile.glue-esp BUILD=$(BUILD) V=$(V)
 	make -f makefiles/Makefile.glue target=$(target) BUILD=$(BUILD) TCP_MSS=$(TCP_MSS) LWIP_FEATURES=$(LWIP_FEATURES) LWIP_IPV6=$(LWIP_IPV6) V=$(V)
 ifeq ($(target),arduino)

--- a/makefiles/Makefile.lwip2
+++ b/makefiles/Makefile.lwip2
@@ -16,16 +16,7 @@ OBJ = \
 BUILD_INCLUDES = -I$(BUILD) -I$(SDK)/include -Iinclude -I../../glue -I../../glue-lwip -I../../glue-lwip/$(target)
 #BUILD_INCLUDES += -I../../lwip2-contrib-src/apps/ping
 
-all: patches $(LWIP_LIB)
-
-patches: .patched
-
-.patched:
-	for p in ../../patches/*.patch; do echo "--------- APPLY PATCH $${p#../../}:"; patch -d .. -p1 < $$p; done
-ifeq ($(target),open)
-	patch -d .. -p1 < ../../patches/open/sdk-mem-macros.patch
-endif
-	touch .patched
+all: $(LWIP_LIB)
 
 include ../../makefiles/Makefile.defs
 include ../../makefiles/Makefile.rules

--- a/makefiles/Makefile.patches
+++ b/makefiles/Makefile.patches
@@ -1,0 +1,9 @@
+
+all: .patched
+
+.patched:
+	for p in ../../patches/*.patch; do echo "--------- APPLY PATCH $${p#../../}:"; patch -d .. -p1 < $$p; done
+ifeq ($(target),open)
+	patch -d .. -p1 < ../../patches/open/sdk-mem-macros.patch
+endif
+	touch .patched

--- a/patches/sys_now_inlined.patch
+++ b/patches/sys_now_inlined.patch
@@ -1,0 +1,13 @@
+diff --git a/src/include/lwip/sys.h b/src/include/lwip/sys.h
+index 168e465..e03e164 100644
+--- a/src/include/lwip/sys.h
++++ b/src/include/lwip/sys.h
+@@ -443,7 +443,7 @@ u32_t sys_jiffies(void);
+  * Not implementing this function means you cannot use some modules (e.g. TCP
+  * timestamps, internal timeouts for NO_SYS==1).
+  */
+-u32_t sys_now(void);
++//u32_t sys_now(void);
+ 
+ /* Critical Region Protection */
+ /* These functions must be implemented in the sys_arch.c file.


### PR DESCRIPTION
It was previoulsy a #define as `millis()`
but its return type `u32` is no longer a long but an int, causing third-party troubles.