### PR TITLE
Define sys_now macro as a function

### DIFF
--- a/glue-lwip/arch/cc.h
+++ b/glue-lwip/arch/cc.h
@@ -85,15 +85,10 @@ typedef uint32_t sys_prot_t;
 ///////////////////////////////
 //// MISSING 
 
-// transparent wrapper for millis()'s return value type from ulong to u32
-#ifdef __cplusplus
-extern "C" {
-#endif
-extern unsigned long millis(void); // arduino definition
-inline __attribute__((always_inline)) u32_t sys_now (void) { return (u32_t)millis(); }
-#ifdef __cplusplus
-}
-#endif
+// b/c we have conflicting typedefs of u32_t and can't substitute funcs,
+// forcibly cast the `millis()` result to lwip's version of u32_t
+// (previous version was `#define sys_now millis`)
+#define sys_now() ((u32_t)millis())
 
 #define LWIP_RAND r_rand	// old lwip uses this useful undocumented function
 #define IPSTR "%d.%d.%d.%d"

--- a/glue-lwip/arch/cc.h
+++ b/glue-lwip/arch/cc.h
@@ -85,7 +85,17 @@ typedef uint32_t sys_prot_t;
 ///////////////////////////////
 //// MISSING 
 
-// b/c we have conflicting typedefs of u32_t and can't substitute funcs,
+// Arduino Core exposes time func with a generic type
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+unsigned long millis(void);
+#ifdef __cplusplus
+}
+#endif
+
+// b/c we have conflicting typedefs of u32_t and ulong and can't substitute funcs,
 // forcibly cast the `millis()` result to lwip's version of u32_t
 // (previous version was `#define sys_now millis`)
 #define sys_now() ((u32_t)millis())


### PR DESCRIPTION
re. esp8266/Arduino#8560

nit: extern already applies to function declarations
nit2: definition vs. declaration :)
nit3: `#define sys_now() ((u32_t)millis())` should have the same result, since we remove func decl of sys_now? same rules as func, must use () to call