### PR TITLE
CMake build fixes and Actions workflow

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,57 @@
+name: CMake build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ github.repository }}
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            build/_deps/lwip2-src
+            build/_deps/lwip2-subbuild
+            esp8266/tools/dist
+          key: ${{ runner.os }}-cmake-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}
+
+      - name: Fetch ESP8266 Core
+        uses: actions/checkout@v3
+        with:
+          path: esp8266
+          repository: esp8266/Arduino
+          fetch-depth: 1
+          submodules: false
+
+      - name: Get toolchain files
+        run: |
+          cd esp8266/tools
+          python get.py -q
+
+      - name: Build
+        env:
+          ESP8266_ARDUINO_CORE_DIR: ${{ github.workspace }}/esp8266
+        run: |
+          cmake \
+             --toolchain=${{ github.workspace }}/${{ github.repository }}/cmake/toolchain.cmake \
+            -DCMAKE_PROGRAM_PATH=${ESP8266_ARDUINO_CORE_DIR}/tools/xtensa-lx106-elf/bin \
+            -DESP8266_ARDUINO_CORE_DIR=${ESP8266_ARDUINO_CORE_DIR} \
+            -S ${{ github.repository }} \
+            -B build
+          cmake --build build/ --parallel $(nproc)

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: ${{ github.repository }}
+          path: repo
 
       - uses: actions/setup-python@v4
         with:
@@ -29,7 +29,7 @@ jobs:
             build/_deps/lwip2-src
             build/_deps/lwip2-subbuild
             esp8266/tools/dist
-          key: ${{ runner.os }}-cmake-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}
+          key: ${{ runner.os }}-cmake-${{ hashFiles('repo/CMakeLists.txt', 'repo/cmake/*.cmake') }}
 
       - name: Fetch ESP8266 Core
         uses: actions/checkout@v3
@@ -49,9 +49,9 @@ jobs:
           ESP8266_ARDUINO_CORE_DIR: ${{ github.workspace }}/esp8266
         run: |
           cmake \
-             --toolchain=${{ github.workspace }}/${{ github.repository }}/cmake/toolchain.cmake \
+             --toolchain=${{ github.workspace }}/repo/cmake/toolchain.cmake \
             -DCMAKE_PROGRAM_PATH=${ESP8266_ARDUINO_CORE_DIR}/tools/xtensa-lx106-elf/bin \
             -DESP8266_ARDUINO_CORE_DIR=${ESP8266_ARDUINO_CORE_DIR} \
-            -S ${{ github.repository }} \
+            -S repo \
             -B build
           cmake --build build/ --parallel $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ project(lwip-glue-builder
 )
 
 list(APPEND compile_options
+    "-nostdlib"
+    "-ffunction-sections"
+    "-fdata-sections"
+    "-falign-functions=4")
+
+list(APPEND compile_options
     "-Wall"
     "-Wextra"
     "-Wpointer-arith"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,24 @@
 cmake_minimum_required(VERSION 3.11)
 project(lwip-glue-builder
-    VERSION 20210928
+    VERSION 20220704
     DESCRIPTION "lwip-glue-builder"
     LANGUAGES C
 )
 
-message(STATUS "c compiler: " ${CMAKE_C_COMPILER})
+list(APPEND compile_options
+    "-Wall"
+    "-Wextra"
+    "-Wpointer-arith"
+    "-Werror=return-type")
+
+list(APPEND compile_options
+    "-Os"
+    "-g")
+
+add_compile_options("${compile_options}")
+
+message(STATUS "compiler: " ${CMAKE_C_COMPILER})
+message(STATUS "default options: " "${compile_options}")
 
 set(UPSTREAM_VERSION "STABLE-2_1_3_RELEASE")
 set(LWIP_TAG ${UPSTREAM_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ list(APPEND compile_options
 
 add_compile_options("${compile_options}")
 
-message(STATUS "compiler: " ${CMAKE_C_COMPILER})
 message(STATUS "default options: " "${compile_options}")
 
 set(UPSTREAM_VERSION "STABLE-2_1_3_RELEASE")

--- a/README-CMake.md
+++ b/README-CMake.md
@@ -9,9 +9,9 @@
 To build & install everything into the specific ESP8266 Core directory:
 ```
 $ cmake \
-    -DESP8266_ARDUINO_CORE_DIR=<path to the arduino core directory>
-    -DCMAKE_TOOLCHAIN_FILE=<path to the current directory>/cmake/toolchain.cmake
-    -DCMAKE_PROGRAM_PATH=<path to the toolchain bin directory>
+    --toolchain=cmake/toolchain.cmake \
+    -DCMAKE_PROGRAM_PATH=<path to the toolchain bin directory> \
+    -DESP8266_ARDUINO_CORE_DIR=<path to the arduino core directory> \
     -B build
 $ cmake --build build
 $ cmake --install build --config Release

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -9,12 +9,8 @@ set(CMAKE_C_COMPILER ${triple}-gcc)
 set(CMAKE_CXX_COMPILER ${triple}-g++)
 
 list(APPEND compile_options
-    "-nostdlib"
     "-mlongcalls"
-    "-mtext-section-literals"
-    "-ffunction-sections"
-    "-fdata-sections"
-    "-falign-functions=4")
+    "-mtext-section-literals")
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,5 +1,6 @@
 include(Compiler/GNU)
 
+set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_LIST_DIR}/esp8266-platform.cmake")
 set(CMAKE_SYSTEM_NAME "Generic")
 
 set(triple xtensa-lx106-elf)

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -6,7 +6,7 @@ set(CMAKE_SYSTEM_NAME "Generic")
 set(triple xtensa-lx106-elf)
 
 set(CMAKE_C_COMPILER ${triple}-gcc)
-set(CMAKE_CXX_COMPILER_TARGET ${triple}-g++)
+set(CMAKE_CXX_COMPILER ${triple}-g++)
 
 list(APPEND compile_options
     "-nostdlib"

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,13 +1,24 @@
 include(Compiler/GNU)
 
-set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_LIST_DIR}/esp8266-platform.cmake")
-set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_SYSTEM_NAME "xtensa")
+set(CMAKE_SYSTEM_PROCESSOR "lx106")
 
-set(CMAKE_C_COMPILER xtensa-lx106-elf-gcc)
-set(CMAKE_CXX_COMPILER xtensa-lx106-elf-g++)
+set(triple xtensa-lx106-elf)
 
-set(CMAKE_C_FLAGS "-Wall -Wextra -c -Os -g -Wpointer-arith -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -falign-functions=4 -MMD -ffunction-sections -fdata-sections")
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -c -Os -g -Wpointer-arith -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals -falign-functions=4 -MMD -ffunction-sections -fdata-sections")
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+set(CMAKE_CXX_COMPILER g++)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+
+list(APPEND compile_options
+    "-nostdlib"
+    "-mlongcalls"
+    "-mtext-section-literals"
+    "-ffunction-sections"
+    "-fdata-sections"
+    "-falign-functions=4")
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,14 +1,11 @@
 include(Compiler/GNU)
 
-set(CMAKE_SYSTEM_NAME "xtensa")
-set(CMAKE_SYSTEM_PROCESSOR "lx106")
+set(CMAKE_SYSTEM_NAME "Generic")
 
 set(triple xtensa-lx106-elf)
 
-set(CMAKE_C_COMPILER gcc)
-set(CMAKE_C_COMPILER_TARGET ${triple})
-set(CMAKE_CXX_COMPILER g++)
-set(CMAKE_CXX_COMPILER_TARGET ${triple})
+set(CMAKE_C_COMPILER ${triple}-gcc)
+set(CMAKE_CXX_COMPILER_TARGET ${triple}-g++)
 
 list(APPEND compile_options
     "-nostdlib"


### PR DESCRIPTION
fix #55 by moving build flags into main and lwip builder .cmake files
also testing this using github actions running on prs and main branch pushes