### PR TITLE
Allow overriding netif->input

### DIFF
--- a/glue-esp/lwip-esp.c
+++ b/glue-esp/lwip-esp.c
@@ -442,8 +442,6 @@ static int netif_is_new (struct netif* netif)
 	else
 		netif->num = SOFTAP_IF;
 
-	netif->input = ethernet_input;
-
 	if (netif_esp[netif->num] == netif)
 	{
 		uprint(DBG "netif (%d): already added\n", netif->num);
@@ -505,9 +503,7 @@ struct netif* netif_add (
 		#endif /* ENABLE_LOOPBACK */
 	netif->state = state;
 
-	uassert(packet_incoming == ethernet_input);
-	(void)packet_incoming;
-	netif->input = ethernet_input;
+	netif->input = packet_incoming;
 
 		#if LWIP_NETIF_HWADDRHINT
 		#error
@@ -559,7 +555,6 @@ void netif_set_addr (struct netif* netif, ip_addr_t* ipaddr, ip_addr_t* netmask,
 	netif->ip_addr.addr = ipaddr->addr;
 	netif->netmask.addr = netmask->addr;
 	netif->gw.addr = gw->addr;
-	uassert(netif->input == ethernet_input);
 
 	// ask blobs
 	struct ip_info set;


### PR DESCRIPTION
Instead of statically calling ethernet_input() (which is actually defined to be ethernet_input_LWIP2), store a pointer to it in netif->input and call that.

This makes it easy to hook into the processing of input packets and implement a little firewall. Of course any code doing this should save the original pointer and call it when applicable. For an example, see:

  https://github.com/martin-ger/esp_wifi_repeater/blob/2499913094a707b79ea4e357273a32755e31c723/user/user_main.c#L693-L697

Also remove various lines where netif->input would be reset. Set it once during netif_add(), and then trust that it wouldn't get changed without reason.